### PR TITLE
Add apply_step_without_grad

### DIFF
--- a/composer/optim/adopt.py
+++ b/composer/optim/adopt.py
@@ -412,6 +412,24 @@ class ADOPT(Optimizer):
 
         return loss
 
+    @torch.no_grad()  # pyright: ignore[reportUntypedFunctionDecorator]
+    def apply_step_without_grad(self):
+        """Apply parameter updates using stored momenta without modifying state."""
+
+        for group in self.param_groups:
+            lr = group['lr']
+            weight_decay = group['weight_decay']
+            initial_lr = group['initial_lr']
+            decouple = group['decouple']
+
+            for p in group['params']:
+                state = self.state[p]
+                if decouple and weight_decay != 0:
+                    decay_factor = (lr / initial_lr) if initial_lr else 1.0
+                    p.mul_(1 - decay_factor * weight_decay)
+
+                p.add_(state['exp_avg'], alpha=-lr)
+
     def dist_reduce_metrics(self, optimizer_metrics):
         local_keys = list(optimizer_metrics.keys())
         all_gathered_keys = dist.all_gather_object(local_keys)


### PR DESCRIPTION
This pull request introduces a new method, `apply_step_without_grad`, to multiple optimizer implementations in the `composer/optim` module. The method enables parameter updates using stored momenta without modifying the optimizer state, improving flexibility for scenarios where state preservation is critical. 

### Additions of `apply_step_without_grad` Method:

#### General Parameter Update Logic:
* Added `apply_step_without_grad` in `composer/optim/adopt.py` to apply parameter updates using stored momenta while optionally decoupling weight decay. This method ensures no changes to the optimizer state.
* Added `apply_step_without_grad` in `composer/optim/qhadopt.py` with similar functionality but includes a `v1` scaling factor specific to QHAdam optimizers.

#### Decoupled Weight Decay:
* Added `apply_step_without_grad` in `composer/optim/decoupled_weight_decay.py` for decoupled weight decay optimizers, leveraging stored momentum buffers for updates without altering the optimizer state.

#### AdamW-Specific Logic:
* Added `apply_step_without_grad` in `composer/optim/decoupled_weight_decay.py` for AdamW optimizers, incorporating bias correction and optional AMSGrad logic during parameter updates.